### PR TITLE
Display worker related information on job list page

### DIFF
--- a/polyphemus/stages_common.py
+++ b/polyphemus/stages_common.py
@@ -100,7 +100,7 @@ class JobTask:
 
 
 @contextmanager
-def work(db, old_state, temp_state, done_state_or_func):
+def work(stage_name, db, old_state, temp_state, done_state_or_func):
     """A context manager for acquiring a job temporarily in an
     exclusive way to work on it. Produce a `JobTask`.
     Done state can either be a valid state string or a function that
@@ -112,7 +112,7 @@ def work(db, old_state, temp_state, done_state_or_func):
     else:
         done_func = done_state_or_func
 
-    job = db.acquire(old_state, temp_state)
+    job = db.acquire(stage_name, old_state, temp_state)
     task = JobTask(db, job)
     try:
         yield task
@@ -124,6 +124,8 @@ def work(db, old_state, temp_state, done_state_or_func):
         task.set_state(state.FAIL)
     else:
         task.set_state(done_func(task))
+    finally:
+        db.release(stage_name)
 
 
 def task_config(task, config):

--- a/polyphemus/templates/joblist.html
+++ b/polyphemus/templates/joblist.html
@@ -32,6 +32,19 @@
     </p>
 </form>
 
+<h2>Workers</h2>
+{% for worker, stages in workers.items() %}
+  <u>{{ worker }}</u>
+  <ul>
+  {% for stage, job in stages.items() %}
+    <li>
+      <b>{{ stage }}</b>:
+      <a href="{{ url_for('show_job', name=job) }}">{{ job }}</a>
+    </li>
+  {% endfor %}
+  </ul>
+{% endfor %}
+
 <h2>Jobs</h2>
 <table>
     <thead>

--- a/polyphemus/worker_common.py
+++ b/polyphemus/worker_common.py
@@ -8,7 +8,7 @@ from .db import ARCHIVE_NAME
 def stage_unpack(db, _):
     """Work stage: unpack source code.
     """
-    with work(db, state.UPLOAD, state.UNPACK, state.MAKE) as task:
+    with work('unpack', db, state.UPLOAD, state.UNPACK, state.MAKE) as task:
         # Unzip the archive into the code directory.
         os.mkdir(task.code_dir)
         task.run(["unzip", "-d", task.code_dir, "{}.zip".format(ARCHIVE_NAME)])
@@ -23,4 +23,9 @@ def stage_unpack(db, _):
                     os.rename(os.path.join(path, fn),
                               os.path.join(task.code_dir, fn))
                 task.log('collapsed directory {}'.format(code_contents[0]))
+
+
+STAGE_NAMES = {
+    'unpack': stage_unpack,
+}
 

--- a/polyphemus/worker_f1.py
+++ b/polyphemus/worker_f1.py
@@ -15,7 +15,7 @@ def stage_f1_make(db, config):
     """
 
     prefix = config["HLS_COMMAND_PREFIX"]
-    with work(db, state.MAKE, state.MAKE_PROGRESS, state.AFI_START) as task:
+    with work('make_f1', db, state.MAKE, state.MAKE_PROGRESS, state.AFI_START) as task:
         task_config(task, config)
 
         # Get the AWS platform ID for F1 builds.
@@ -54,7 +54,7 @@ def stage_afi(db, config):
     """Work stage: create the AWS FPGA binary and AFI from the *.xclbin
     (Xilinx FPGA binary file).
     """
-    with work(db, state.AFI_START, state.AFI, state.HLS_FINISH) as task:
+    with work('afi', db, state.AFI_START, state.AFI, state.HLS_FINISH) as task:
         # Clean up any generated files from previous runs.
         task.run(
             ['rm -rf to_aws *afi_id.txt \
@@ -124,7 +124,7 @@ def stage_f1_fpga_execute(db, config):
     hard-codes the root password as root---not terribly secure, so the
     board should clearly not be on a public network).
     """
-    with work(db, state.HLS_FINISH, state.RUN, state.DONE) as task:
+    with work('exec_f1', db, state.HLS_FINISH, state.RUN, state.DONE) as task:
 
         # Do nothing in this stage if we're just running estimation.
         if task['config'].get('estimate') or task['config'].get('skipexec'):
@@ -151,3 +151,10 @@ def stage_f1_fpga_execute(db, config):
             cwd=CODE_DIR,
             timeout=9000
         )
+
+
+STAGE_NAMES = {
+    "make_f1": stage_f1_make,
+    "afi": stage_afi,
+    "exec_f1": stage_f1_fpga_execute,
+}

--- a/polyphemus/worker_sdsoc.py
+++ b/polyphemus/worker_sdsoc.py
@@ -23,7 +23,7 @@ def stage_sdsoc_make(db, config):
 
     prefix = config["HLS_COMMAND_PREFIX"]
 
-    with work(db, state.MAKE, state.MAKE_PROGRESS, state.HLS_FINISH) as task:
+    with work('make_sdsoc', db, state.MAKE, state.MAKE_PROGRESS, state.HLS_FINISH) as task:
         task_config(task, config)
 
         # Simple make invocation for SDSoC.
@@ -60,7 +60,7 @@ def stage_zynq_fpga_execute(db, config):
     hard-codes the root password as root---not terribly secure, so the
     board should clearly not be on a public network).
     """
-    with work(db, state.HLS_FINISH, state.RUN, state.DONE) as task:
+    with work('exec_zynq', db, state.HLS_FINISH, state.RUN, state.DONE) as task:
 
         # Do nothing in this stage if we're just running estimation.
         if task['config'].get('estimate') or task['config'].get('skipexec'):
@@ -93,3 +93,9 @@ def stage_zynq_fpga_execute(db, config):
             ],
             timeout=120
         )
+
+
+STAGE_NAMES = {
+    'make_sdsoc': stage_sdsoc_make,
+    'exec_zynq': stage_zynq_fpga_execute,
+}

--- a/polyphemus/workproc.py
+++ b/polyphemus/workproc.py
@@ -42,11 +42,11 @@ class WorkProc:
         strings in worker.KNOWN_STAGES then create workers mapping to those.
         """
         if stages_conf is None:
-            stages = worker.default_work_stages(self.config)
-        else:
-            stages = [worker.KNOWN_STAGES[stage] for stage in stages_conf]
+            stages_conf = worker.default_work_stages(self.config)
 
-        print(stages)
+        print("Worker", self.name, "running with stages:", stages_conf)
+
+        stages = [worker.KNOWN_STAGES[stage] for stage in stages_conf]
 
         for thread in worker.work_threads(stages, self.config, self.db):
             if not thread.is_alive():

--- a/polyphemus/workproc.py
+++ b/polyphemus/workproc.py
@@ -98,6 +98,7 @@ class WorkProc:
 
         except KeyboardInterrupt:
             print ("Shutting down worker.")
+            self.db.remove_worker(self.name)
             pass
 
 


### PR DESCRIPTION
**High level goal**: Display all the workers currently associated with this server instance and track which jobs each of the stages for each worker is working on.

### Implementation
- Each worker starts with a name and a bunch of stages.
- Each DB creates a json file under `instance/worker/<worker-name>` for the worker associated with it**. The json file contains associations for each stage and job ids it's working on.
- Every time a `work` stage acquires the job, the DB associated with it updates the JSON file to reflect the job currently being run by the stage.
- When a job finishes, the db `release`s the stage from job ID and updates the JSON file to reflect this.
- When a worker (in a separate process) is killed, it removes it's JSON file.

### Issues
This implementation might be implicitly breaking the relationship b/w `WorkProc` and `DB` interfaces.

** Note that this is done at DB creation time so DB's that might be re-used by workers will not have this association. We currently create a new DB for each instance so this isn't a problem but we should clarify what DB's are meant to do. Right now they provide a structured interface over the `instance` directory.