### PR TITLE
stop sw_emu and hw_emu jobs from entering AFI stage

### DIFF
--- a/polyphemus/worker_f1.py
+++ b/polyphemus/worker_f1.py
@@ -55,6 +55,8 @@ def stage_afi(db, config):
     (Xilinx FPGA binary file).
     """
     with work(db, state.AFI_START, state.AFI, state.HLS_FINISH) as task:
+        # sw_emu and hw_emu does not require AFI
+        if not task['mode'] == 'hw': return
         # Clean up any generated files from previous runs.
         task.run(
             ['rm -rf to_aws *afi_id.txt \

--- a/polyphemus/worker_f1.py
+++ b/polyphemus/worker_f1.py
@@ -56,7 +56,7 @@ def stage_afi(db, config):
     """
     with work(db, state.AFI_START, state.AFI, state.HLS_FINISH) as task:
         # sw_emu and hw_emu do not require AFI
-        if not task['mode'] == 'hw': 
+        if task['mode'] != 'hw': 
             task.log('skipping AFI stage for {}'.format(task['mode']))
             return
         # Clean up any generated files from previous runs.

--- a/polyphemus/worker_f1.py
+++ b/polyphemus/worker_f1.py
@@ -55,8 +55,10 @@ def stage_afi(db, config):
     (Xilinx FPGA binary file).
     """
     with work(db, state.AFI_START, state.AFI, state.HLS_FINISH) as task:
-        # sw_emu and hw_emu does not require AFI
-        if not task['mode'] == 'hw': return
+        # sw_emu and hw_emu do not require AFI
+        if not task['mode'] == 'hw': 
+            task.log('skipping AFI stage for {}'.format(task['mode']))
+            return
         # Clean up any generated files from previous runs.
         task.run(
             ['rm -rf to_aws *afi_id.txt \


### PR DESCRIPTION
Currently, all jobs will enter AFI right after make and this caused sw_emu jobs to fail. I couldn't find a clean way to change the stage after make to be dependent on the mode so I made AFI stage return if the mode is sw_emu.